### PR TITLE
Add `action` to list of supported turnstile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ export default {
 
 ## Customization options
 
-| Prop            | Type                          | Description                                                                                      | Required | Default    |
-| --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ | -------- | ---------- |
-| site-key        | `String`                      | Your Turnstile sitekey - [Docs](https://developers.cloudflare.com/turnstile/get-started/)        | Yes      | N/A        |
-| v-model         | `String`                      | Binding that contains the token returned by the Turnstile widget                                 | Yes      | N/A        |
-| reset-interval  | `Number`                      | Get a fresh token after `reset-interval` milliseconds - Turnstile tokens only last for 5 minutes | No       | `295000`   |
-| size            | `'normal' \| 'compact'`       | Widget size                                                                                      | No       | `'normal'` |
-| theme           | `'light' \| 'dark' \| 'auto'` | Widget theme - auto respects the user's browser preference                                       | No       | `'auto'`   |
-| render-on-mount | `Boolean`                     | Automatically render Turnstile widget after component mounts                                     | No       | `true`     |
+| Prop            | Type                          | Description                                                                                                                           | Required | Default    |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- |
+| site-key        | `String`                      | Your Turnstile sitekey - [Docs](https://developers.cloudflare.com/turnstile/get-started/)                                             | Yes      | N/A        |
+| v-model         | `String`                      | Binding that contains the token returned by the Turnstile widget                                                                      | Yes      | N/A        |
+| reset-interval  | `Number`                      | Get a fresh token after `reset-interval` milliseconds - Turnstile tokens only last for 5 minutes                                      | No       | `295000`   |
+| size            | `'normal' \| 'compact'`       | Widget size                                                                                                                           | No       | `'normal'` |
+| theme           | `'light' \| 'dark' \| 'auto'` | Widget theme - auto respects the user's browser preference                                                                            | No       | `'auto'`   |
+| action          | `String`                      | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. | No       | `''`   |
+| render-on-mount | `Boolean`                     | Automatically render Turnstile widget after component mounts                                                                          | No       | `true`     |
 
 ## Methods
 

--- a/src/VueTurnstile.vue
+++ b/src/VueTurnstile.vue
@@ -55,6 +55,11 @@ export default defineComponent({
       required: false,
       default: 'auto',
     },
+    action: {
+      type: String,
+      required: false,
+      default: '',
+    },
     renderOnMount: {
       type: Boolean,
       required: false,
@@ -75,6 +80,7 @@ export default defineComponent({
         theme: this.theme,
         size: this.size,
         callback: this.callback,
+        action: this.action,
       };
     },
   },


### PR DESCRIPTION
Hello!

We'd like to use this plugin to integrate with turnstile but looks like it doesn't support `action` parameter: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/

Please let me know if you need any help to verify my changes.


