### PR TITLE
chore(deps): keep vue as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vue3",
     "library"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "vue": "^3.2.45"
   },
   "devDependencies": {
@@ -48,6 +48,7 @@
     "prettier": "^2.8.1",
     "typescript": "^4.9.3",
     "vite": "^4.0.0",
+    "vue": "^3.2.45",
     "vue-tsc": "^1.0.11"
   }
 }


### PR DESCRIPTION
We need to keep vue in the peer dependency in case we want to install an alternative version of vue in our project.