### PR TITLE
Add error and unsupported callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ export default {
 | `reset()`  | Resets the widget  |
 | `render()` | Renders the widget |
 
+
+## Events
+
+| Method         | Params  | Description        |
+| -------------- | ------- | ------------------ |
+| `@error`       | `code`  | Callback invoked when there is an error (e.g. network error or the challenge failed). |
+| `@unsupported` | -       | Callback invoked when a given client/browser is not supported by Turnstile. |
+
+
 ## Author
 
 Rui Gomes  

--- a/src/VueTurnstile.vue
+++ b/src/VueTurnstile.vue
@@ -89,11 +89,21 @@ export default defineComponent({
         callback: this.callback,
         action: this.action,
         appearance: this.appearance,
+        'error-callback': this.errorCallback,
+        'unsupported-callback': this.unsupportedCallback,
       };
     },
   },
 
   methods: {
+    unsupportedCallback() {
+      this.$emit('unsupported');
+    },
+
+    errorCallback(code: string) {
+      this.$emit('error', code);
+    },
+
     callback(token: string) {
       this.$emit('update:modelValue', token);
       this.startResetTimeout();


### PR DESCRIPTION
Adds error and unsupported callbacks support as events. Those callbacks are very important to give feedback to the users on why the captcha is not working or why the test failed.

**Documentation:**
https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations
https://developers.cloudflare.com/turnstile/reference/client-side-errors