### PR TITLE
Fix exports.require path to point to correct file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ".": {
       "types": "./dist/VueTurnstile.vue.d.ts",
       "import": "./dist/vue-turnstile.js",
-      "require": "./dist/vue-turnstile.umd.js"
+      "require": "./dist/vue-turnstile.umd.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
### Fix `exports.require` Path in `package.json`

#### Description
This pull request fixes the `exports.require` path in the `package.json` file to point to the correct file (`./dist/vue-turnstile.umd.cjs`). The current path (`./dist/vue-turnstile.umd.js`) does not exist, which causes issues in production builds.

#### Testing
The change has been tested locally in a production build environment and works as expected.

Thank you for considering this fix!
